### PR TITLE
CNPJ contendo alfanuméricos que entrará em vigor em 01/07/2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Atualmente em construção, o objetivo é fornecer uma biblioteca de recursos ú
 #### **Extensões para Documentos** ([detalhes](https://github.com/wagnerpt/W4G.Extensions/wiki/Methods#documentos))
 
 - **CPF**: [CpfIsValid](https://github.com/wagnerpt/W4G.Extensions/wiki/CpfIsValid), [CpfCorrect](https://github.com/wagnerpt/W4G.Extensions/wiki/CpfCorrect), [CpfFormat](https://github.com/wagnerpt/W4G.Extensions/wiki/CpfFormat).
-- **CNPJ**: [CnpjIsValid](https://github.com/wagnerpt/W4G.Extensions/wiki/CnpjIsValid), [CnpjCorrect](https://github.com/wagnerpt/W4G.Extensions/wiki/CnpjCorrect), [CnpjFormat](https://github.com/wagnerpt/W4G.Extensions/wiki/CnpjFormat).
+- **CNPJ**: [CnpjIsValid](https://github.com/wagnerpt/W4G.Extensions/wiki/CnpjIsValid), [CnpjCorrect](https://github.com/wagnerpt/W4G.Extensions/wiki/CnpjCorrect), [CnpjFormat](https://github.com/wagnerpt/W4G.Extensions/wiki/CnpjFormat).	
+*Já preparado para o CNPJ contendo alfanuméricos que entrará em vigor em 01/07/2026 ([IN RFB nº 2119](http://normas.receita.fazenda.gov.br/sijut2consulta/link.action?idAto=127567)).
 
 #### **Extensões para Enums** ([detalhes](https://github.com/wagnerpt/W4G.Extensions/wiki/Methods#enums))
 - [Description](https://github.com/wagnerpt/W4G.Extensions/wiki/Enum.Description), [IsValid](https://github.com/wagnerpt/W4G.Extensions/wiki/Enum.IsValid), [HasValue](https://github.com/wagnerpt/W4G.Extensions/wiki/Enum.HasValue), [ToList](https://github.com/wagnerpt/W4G.Extensions/wiki/Enum.ToList).

--- a/src/W4G.Extensions/CHANGELOG
+++ b/src/W4G.Extensions/CHANGELOG
@@ -1,4 +1,8 @@
-﻿v1.0.6
+﻿v1.0.7
+======
+  * CNPJ contendo alfanuméricos que entrará em vigor em 01/07/2026 ([IN RFB nº 2119](http://normas.receita.fazenda.gov.br/sijut2consulta/link.action?idAto=127567)).
+
+v1.0.6
 ======
   * Inclusão de métodos para `Enum` (Description, IsValid, HasValue, ToList)
   * Inclusão do Método `FromXml` para converter uma string XML em objeto

--- a/src/W4G.Extensions/W4G.Extensions.csproj
+++ b/src/W4G.Extensions/W4G.Extensions.csproj
@@ -14,9 +14,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Classlib;.NET;GitHub;Extensions</PackageTags>
     <Authors>W4G</Authors>
-    <AssemblyVersion>1.0.6</AssemblyVersion>
-    <FileVersion>1.0.6</FileVersion>
-    <Version>1.0.6</Version>
+    <AssemblyVersion>1.0.7</AssemblyVersion>
+    <FileVersion>1.0.7</FileVersion>
+    <Version>1.0.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/W4G.Extensions/documents/CnpjExtensions.cs
+++ b/src/W4G.Extensions/documents/CnpjExtensions.cs
@@ -5,9 +5,11 @@ namespace W4G.Extensions.documents;
 public static class CnpjExtensions
 {
     #region private
+    private static bool CnpjAlfa = DateTime.Today >= new DateTime(2026, 7, 1);
+
     private static int CalcDigits(string CNPJ)
     {
-        var cnpj = CNPJ.OnlyNumbers().PadLeft(14, '0');
+        var cnpj = (CnpjAlfa ? CNPJ.OnlyAlphanumeric(): CNPJ.OnlyNumbers()).PadLeft(14, '0').ToUpper();
 
         if (cnpj.Length != 14)
             throw new ArgumentException("CNPJ deve conter 14 dígitos");
@@ -18,14 +20,14 @@ public static class CnpjExtensions
         int soma = 0;
         //Calcula o primeiro dígito verificador
         for (int i = 0; i < 12; i++)
-            soma += int.Parse(cnpj[i].ToString()) * multiplicadores1[i];
+            soma += (cnpj[i] - 48) * multiplicadores1[i];
         int resto = soma % 11;
         int digitoVerificador1 = resto < 2 ? 0 : 11 - resto;
 
         soma = 0;
         //Calcula o segundo dígito verificador
         for (int i = 0; i < 13; i++)
-            soma += int.Parse(cnpj[i].ToString()) * multiplicadores2[i];
+            soma += (cnpj[i] - 48) * multiplicadores2[i];
         resto = soma % 11;
         int digitoVerificador2 = resto < 2 ? 0 : 11 - resto;
 
@@ -38,13 +40,13 @@ public static class CnpjExtensions
         if (!CnpjIsValid(CNPJ))
             throw new ArgumentException("Cnpj Inválido");
 
-        return Regex.Replace(CNPJ.OnlyNumbers(), @"(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})", @"$1.$2.$3/$4-$5");
+        return Regex.Replace((CnpjAlfa ? CNPJ.OnlyAlphanumeric() : CNPJ.OnlyNumbers()), @"(\w{2})(\w{3})(\w{3})(\w{4})(\d{2})", @"$1.$2.$3/$4-$5");
     }
 
     public static bool CnpjIsValid(this string CNPJ)
     {
         var cnpj = CNPJ.Replace(".", "").Replace("-", "").Replace("/", "").PadLeft(14, '0');
-        var cnpjNumbers = CNPJ.OnlyNumbers().PadLeft(14, '0');
+        var cnpjNumbers = (CnpjAlfa ? CNPJ.OnlyAlphanumeric() : CNPJ.OnlyNumbers()).PadLeft(14, '0');
 
         if (cnpj.Length > 14 || cnpj != cnpjNumbers)
             return false;
@@ -54,7 +56,7 @@ public static class CnpjExtensions
 
     public static string CnpjCorrect(this string CNPJ)
     {
-        var cnpj = CNPJ.OnlyNumbers().PadLeft(14, '0');
+        var cnpj = (CnpjAlfa ? CNPJ.OnlyAlphanumeric() : CNPJ.OnlyNumbers()).PadLeft(14, '0');
         if (cnpj.Length > 14)
             throw new ArgumentException("CNPJ deve conter 14 dígitos");
         return $"{cnpj.Substring(0, 12)}{CalcDigits(cnpj).ToString("00")}";

--- a/src/W4G.Extensions/strings/OnlyNumbersExtensions.cs
+++ b/src/W4G.Extensions/strings/OnlyNumbersExtensions.cs
@@ -15,5 +15,17 @@ namespace W4G.Extensions
                 return null;
             return Regex.Replace(value.ToString(), @"[^\d]", "");
         }
+
+        /// <summary>
+        /// Retorna somente os alfanuméricos contido em uma string
+        /// </summary>
+        /// <param name="value">Objeto com o valor em texto</param>
+        /// <returns>Texto contendo apenas alfanuméricos</returns>
+        public static string OnlyAlphanumeric(this string value)
+        {
+            if (value == null)
+                return null;
+            return Regex.Replace(value.ToString(), @"[^\w]", "");
+        }
     }
 }

--- a/tests/W4G.Extensions.Test/documents/CnpjTest.cs
+++ b/tests/W4G.Extensions.Test/documents/CnpjTest.cs
@@ -10,7 +10,9 @@ public class CnpjTest
     public void CnpjFormat()
     {
         Assert.AreEqual("89.539.598/0001-03", "89539598000103".CnpjFormat());
+        Assert.AreEqual("12.ABC.345/01DE–35", "12ABC34501DE35".CnpjFormat());
         Assert.ThrowsException<ArgumentException>(() => "89539598000104".CnpjFormat());
+        Assert.ThrowsException<ArgumentException>(() => "12ABC34501DE36".CnpjFormat());
     }
 
     [TestMethod]
@@ -21,6 +23,8 @@ public class CnpjTest
         Assert.AreEqual(false, "89539598000104".CnpjIsValid());
         Assert.AreEqual(false, "999999999999".CnpjIsValid());
         Assert.AreEqual(false, "89539598000103A".CnpjIsValid());
+        Assert.AreEqual(true, "12ABC34501DE35".CnpjIsValid());
+        Assert.AreEqual(true, "A2ABC34501DE35".CnpjIsValid());
     }
 
     [TestMethod]
@@ -29,6 +33,7 @@ public class CnpjTest
         Assert.AreEqual("89539598000103", "89539598000103".CnpjCorrect());
         Assert.AreEqual("89539598000103", "89.539.598/0001-03".CnpjCorrect());
         Assert.AreEqual("89539598000103", "89539598000104".CnpjCorrect());
-        Assert.AreEqual("89539598000103", "89539598000103A".CnpjCorrect());
+        Assert.AreEqual("89539598000103", "8953959800010A".CnpjCorrect());
+        Assert.AreEqual("12ABC34501DE35", "12.ABC.345/01DE–35".CnpjCorrect());
     }
 }


### PR DESCRIPTION
CNPJ contendo alfanuméricos que entrará em vigor em 01/07/2026 ([IN RFB nº 2119](http://normas.receita.fazenda.gov.br/sijut2consulta/link.action?idAto=127567)).